### PR TITLE
Update README to remove Hugging Face token instructions

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -7,10 +7,6 @@ This docker container runs the TiRex model and provides the following APIs to in
 
 ## Using the docker container
 
-<strong>ℹ️ Note:</strong> To gain access to our model weights, please generate yourself a Hugging Face access token.
-    <a href="https://huggingface.co/settings/tokens/new?canReadGatedRepos=true&tokenType=fineGrained" target="_blank" style="color: #1890ff; text-decoration: none; font-weight: bold;">Click here</a>
-    to generate the token and ensure that you enable <code>"Read access to contents of all public gated repos you can access".</code> When running the Docker image, pass your generated huggingface token as an environment variable.
-
 These images are Linux containers. The CPU image targets `linux/amd64` and `linux/arm64`; run it on Linux, macOS, or Windows with Docker Desktop's Linux container backend. The GPU image is a CUDA Linux image for `linux/amd64`; run it on Linux with the NVIDIA Container Toolkit or on Windows with Docker Desktop's WSL2 backend and NVIDIA WSL GPU support.
 
 ### HTTP API
@@ -299,8 +295,6 @@ docker run --rm --gpus 1 -p 8000:8000 `
 ```
 
 ## Development Setup
-
-Running the server (and the tests) also downloads the gated weights, so set `HF_TOKEN` in your environment first (`export HF_TOKEN=hf_xxxxxxxx` on Linux/macOS Bash, `$env:HF_TOKEN="hf_xxxxxxxx"` on Windows PowerShell) or run `huggingface-cli login`.
 
 ### Install Python dependencies:
 ```


### PR DESCRIPTION
We disabled model gating, therefore removed instructions for generating Hugging Face access token and using it with Docker.