### PR TITLE
chore(source): standardize copyright headers

### DIFF
--- a/inference/tests/conftest.py
+++ b/inference/tests/conftest.py
@@ -21,7 +21,7 @@ mqtt_host = os.getenv("TEST_MQTT_BROKER_HOST", "broker.emqx.io")
 mqtt_port = int(os.getenv("TEST_MQTT_BROKER_PORT", "1883"))
 
 
-def wait_for_api(healthcheck_url, timeout=30, process=None):
+def wait_for_api(healthcheck_url, timeout=60, process=None):
     print("Start for model load")
     for i in range(timeout):
         if process is not None and process.poll() is not None:
@@ -63,7 +63,7 @@ def api_server():
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
             )
-        wait_for_api(f"{base_url}/health", timeout=30, process=process)
+        wait_for_api(f"{base_url}/health", timeout=60, process=process)
 
         yield base_url
     finally:

--- a/src/tirex2/__init__.py
+++ b/src/tirex2/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from .api_adapter import ForecastModel
 from .base import load_model
 from .model import TimeseriesType, TiRex2

--- a/src/tirex2/__init__.py
+++ b/src/tirex2/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from .api_adapter import ForecastModel
 from .base import load_model
 from .model import TimeseriesType, TiRex2

--- a/src/tirex2/api_adapter/__init__.py
+++ b/src/tirex2/api_adapter/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from .forecast import ForecastModel
 
 __all__ = ["ForecastModel"]

--- a/src/tirex2/api_adapter/__init__.py
+++ b/src/tirex2/api_adapter/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from .forecast import ForecastModel
 
 __all__ = ["ForecastModel"]

--- a/src/tirex2/api_adapter/forecast.py
+++ b/src/tirex2/api_adapter/forecast.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """High-level forecasting API wrapping a :class:`TiRex2` backbone."""
 
 import logging

--- a/src/tirex2/api_adapter/forecast.py
+++ b/src/tirex2/api_adapter/forecast.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """High-level forecasting API wrapping a :class:`TiRex2` backbone."""
 
 import logging
@@ -150,8 +152,6 @@ def build_fev_timeseries(
     merged_ds = datasets.concatenate_datasets([past_data, future_data_renamed], axis=1).with_format("torch")
 
     def map_sample(sample):
-        # ``.map`` does not apply the dataset's ``with_format("torch")`` transform, so the
-        # callback receives plain Python lists; convert them to tensors explicitly.
         covariates = []
         for col in known_dynamic_columns:
             try:

--- a/src/tirex2/api_adapter/gluon.py
+++ b/src/tirex2/api_adapter/gluon.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """GluonTS data extraction and forecast formatting for the multivariate adapter."""
 
 import pandas as pd

--- a/src/tirex2/api_adapter/gluon.py
+++ b/src/tirex2/api_adapter/gluon.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """GluonTS data extraction and forecast formatting for the multivariate adapter."""
 
 import pandas as pd

--- a/src/tirex2/api_adapter/standard_adapter.py
+++ b/src/tirex2/api_adapter/standard_adapter.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Assemble batches of :class:`TimeseriesType` from plain tensor/array/list inputs."""
 
 import itertools

--- a/src/tirex2/api_adapter/standard_adapter.py
+++ b/src/tirex2/api_adapter/standard_adapter.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Assemble batches of :class:`TimeseriesType` from plain tensor/array/list inputs."""
 
 import itertools

--- a/src/tirex2/base.py
+++ b/src/tirex2/base.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Loading utilities for inference-ready :class:`TiRex2` checkpoints."""
 
 from pathlib import Path

--- a/src/tirex2/base.py
+++ b/src/tirex2/base.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Loading utilities for inference-ready :class:`TiRex2` checkpoints."""
 
 from pathlib import Path

--- a/src/tirex2/demo.py
+++ b/src/tirex2/demo.py
@@ -1,5 +1,6 @@
 # Copyright (c) NXAI GmbH.
-# to prevent warnings that 'Demo' is not found in class-function annotations
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence

--- a/src/tirex2/demo.py
+++ b/src/tirex2/demo.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 # to prevent warnings that 'Demo' is not found in class-function annotations
 from __future__ import annotations
 

--- a/src/tirex2/model/__init__.py
+++ b/src/tirex2/model/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from .tirex2 import TiRex2
 from .types import TimeseriesType
 

--- a/src/tirex2/model/__init__.py
+++ b/src/tirex2/model/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from .tirex2 import TiRex2
 from .types import TimeseriesType
 

--- a/src/tirex2/model/component/__init__.py
+++ b/src/tirex2/model/component/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from .attention_block import AttentionBlock, AttentionLayer
 from .bi_xlstm import BiXLSTM
 from .flashrnn_slstm import FlashRNNLayerConfig, sLSTMFlashRNNLayer

--- a/src/tirex2/model/component/__init__.py
+++ b/src/tirex2/model/component/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from .attention_block import AttentionBlock, AttentionLayer
 from .bi_xlstm import BiXLSTM
 from .flashrnn_slstm import FlashRNNLayerConfig, sLSTMFlashRNNLayer

--- a/src/tirex2/model/component/attention_block.py
+++ b/src/tirex2/model/component/attention_block.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 import math
 import warnings
 from typing import Any
@@ -301,7 +303,6 @@ class AttentionBlock(torch.nn.Module):
         self.dropout = dropout
         self.use_qk_norm = use_qk_norm
         self.use_flex_attention = use_flex_attention
-        # disable_singleton_attention has no effect when disable_singleton_block is set
         self._collect_group_stats_this_step = False
         self.use_post_norm = False
 

--- a/src/tirex2/model/component/attention_block.py
+++ b/src/tirex2/model/component/attention_block.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 import math
 import warnings
 from typing import Any
@@ -89,7 +90,7 @@ class AttentionLayer(torch.nn.Module):
         computing attention scores (default: True).
     use_flex_attention: bool
         Whether to use FlexAttention instead of scaled dot product attention
-        when attention weights are not requested (default: False).
+        (default: False).
     """
 
     def __init__(
@@ -99,7 +100,6 @@ class AttentionLayer(torch.nn.Module):
         n_heads: int = 4,
         dropout: float = 0,
         disable_singleton_attention: bool = False,
-        return_attention_scores: bool = False,
         use_rope: bool = False,
         no_qk_scale: bool = False,
         use_qk_norm: bool = True,
@@ -111,7 +111,6 @@ class AttentionLayer(torch.nn.Module):
         self.n_heads: int = n_heads
         self.dropout: float = dropout
         self.disable_singleton_attention: bool = disable_singleton_attention
-        self.return_attention_scores: bool = return_attention_scores
         self.use_rope: bool = use_rope
         self.use_qk_norm: bool = use_qk_norm
         self.use_flex_attention: bool = use_flex_attention
@@ -187,9 +186,8 @@ class AttentionLayer(torch.nn.Module):
 
         Returns
         -------
-        tuple[torch.Tensor, None]
-            The attention-transformed tokens of shape `[B, L, D]` and a placeholder for attention weights
-            (currently `None`).
+        torch.Tensor
+            The attention-transformed tokens of shape `[B, L, D]`.
         """
         _, L, _ = x.shape
 
@@ -282,54 +280,10 @@ class AttentionLayer(torch.nn.Module):
 
 
 class AttentionBlock(torch.nn.Module):
-    """Transformer attention block with configurable pre/post normalization.
+    """Transformer attention block with RMS-normalized attention and FFN residuals.
 
-    Combines multi-head attention with a feed-forward network and residual
-    connections. By default the block uses pre-normalization (RMSNorm), while
-    post-normalization can optionally be enabled in addition to or instead of
-    pre-normalization. Supports optional RoPE positional encoding and
-    group-wise attention masking.
-
-    Parameters
-    ----------
-    input_dim : int
-        Dimension of input features
-    n_heads : int
-        Number of attention heads
-    dropout : float
-        Dropout probability for attention and FFN layers
-    act_fn : torch.nn.Module
-        Activation function for the FFN
-    use_group_attention : bool
-        Whether to use group-wise attention masking
-    use_rope : bool, optional
-        Whether to use Rotary Position Embedding (default: False)
-    rope_max_seq_len : int, optional
-        Maximum sequence length for RoPE precomputation (default: 2048)
-    rope_base : float, optional
-        Base for RoPE frequency computation (default: 10000.0)
-    disable_singleton_attention : bool, optional
-        Zero out the attention output for singleton group tokens so only their
-        residual is propagated. Has no effect when ``disable_singleton_block``
-        is True (default: False).
-    disable_singleton_block : bool, optional
-        Pass singleton group tokens through the entire block unchanged, skipping
-        both the attention layer and the FFN. When True, ``disable_singleton_attention``
-        has no effect (default: False).
-    normalize_attn_by_group_size : bool, optional
-        Scale the attention residual by ``1 / sqrt(group_size)`` per token so
-        that the magnitude of the attention contribution stays comparable
-        regardless of whether the group has 3 or 100 variates (default: False).
-    use_pre_norm : bool, optional
-        Apply RMSNorm before each sublayer input (default: True).
-    use_post_norm : bool, optional
-        Apply RMSNorm after each residual addition (default: False).
-    use_qk_norm : bool, optional
-        Whether to apply RMS normalization to the query and key vectors in the
-        attention layer before computing attention scores (default: True).
-    use_flex_attention : bool, optional
-        Whether the attention layer should use FlexAttention by default
-        (default: False).
+    The block combines multi-head attention with a feed-forward network. Optional
+    group-wise attention masks are applied when group IDs are supplied at forward time.
     """
 
     def __init__(
@@ -367,7 +321,6 @@ class AttentionBlock(torch.nn.Module):
         )
 
         self.norm_ffn = torch.nn.RMSNorm(self.input_dim, eps=1e-6)
-        # FFN with expansion factor of 4 (plain MLP) or 8/3 (GatedMLP/SwiGLU)
         self.ffn_hidden_dim = 4 * self.input_dim
         self.ffn = MLP(
             d_model=self.input_dim,
@@ -383,7 +336,7 @@ class AttentionBlock(torch.nn.Module):
         group_vector: torch.Tensor | None = None,
         target_mask: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """Forward pass through attention and FFN with residual connections.
 
         Parameters
@@ -399,10 +352,8 @@ class AttentionBlock(torch.nn.Module):
 
         Returns
         -------
-        torch.Tensor or tuple[torch.Tensor, torch.Tensor]
-            If return_attention_scores is False, returns output tensor of shape [B, L, D].
-            If return_attention_scores is True, returns tuple of (output [B, L, D],
-            attention_scores [B, H, L, L])
+        torch.Tensor
+            Output tensor of shape [B, L, D].
         """
         x_in = x
 
@@ -426,14 +377,11 @@ class AttentionBlock(torch.nn.Module):
                     f"target_mask not sliced consistently: tm={target_mask.shape[0]}, x={x.shape[1]}"
                 )
 
-        # --- Block-Body (with L_sub if use_gather, else L) ---
         x_attn = self.attn(self.norm_attn(x), group_vector=group_vector, target_mask=target_mask)
         x = x + x_attn
 
         x_ffn = self.ffn(self.norm_ffn(x))
         x = x + x_ffn
-        # --- End Block-Body ---
-
         # Scatter non-singleton outputs back into the full-L tensor
         if group_vector is not None:
             out = x_in.clone()

--- a/src/tirex2/model/component/bi_xlstm.py
+++ b/src/tirex2/model/component/bi_xlstm.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """This module exposes xLSTM blocks combining recurrent kernels with feed-forward adapters."""
 
 from typing import Literal

--- a/src/tirex2/model/component/bi_xlstm.py
+++ b/src/tirex2/model/component/bi_xlstm.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """This module exposes xLSTM blocks combining recurrent kernels with feed-forward adapters."""
 
 from typing import Literal

--- a/src/tirex2/model/component/flashrnn_slstm.py
+++ b/src/tirex2/model/component/flashrnn_slstm.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """FlashRNN-backed sLSTM layers and configuration helpers."""
 
 from abc import ABC, abstractmethod
@@ -135,7 +136,7 @@ class _FlashRNNLayer(nn.Module, ABC):
         conv_state: torch.Tensor | None = None,
         slstm_state: torch.Tensor | None = None,
     ):
-        """Single-step recurrent update used for streaming evaluation."""
+        """Perform a single recurrent update."""
         batch_size, _, _ = x.shape
 
         if self.config.conv1d_kernel_size > 0:
@@ -198,18 +199,13 @@ class _FlashRNNLayer(nn.Module, ABC):
 
         Wx = torch.stack(gates, dim=2)
         Wx = einops.rearrange(Wx, "... (h hd) -> ... h hd", h=self.config.num_heads)
-        # logging.warning(f"Wx: {Wx.shape}")
-        # logging.warning(f"R: {self.get_R().shape}")
-        # logging.warning(f"b: {self.get_bias().shape}")
         y, _ = flashrnn(
             Wx=Wx,
             R=self.get_R(),
             b=self.get_bias(),
             config=self.config,
         )
-        # TODO What is the return of flashrnn?
         y = y[0]
-        # logging.warning(f"Output: {y.shape}")
 
         y = self.dropout(y)
 

--- a/src/tirex2/model/component/flashrnn_slstm.py
+++ b/src/tirex2/model/component/flashrnn_slstm.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """FlashRNN-backed sLSTM layers and configuration helpers."""
 
 from abc import ABC, abstractmethod

--- a/src/tirex2/model/component/layernorm.py
+++ b/src/tirex2/model/component/layernorm.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 import torch
 from torch import nn
 

--- a/src/tirex2/model/component/layernorm.py
+++ b/src/tirex2/model/component/layernorm.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 import torch
 from torch import nn
 

--- a/src/tirex2/model/component/mlp.py
+++ b/src/tirex2/model/component/mlp.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Feed-forward network module with optional residual connection."""
 
 import torch

--- a/src/tirex2/model/component/mlp.py
+++ b/src/tirex2/model/component/mlp.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Feed-forward network module with optional residual connection."""
 
 import torch

--- a/src/tirex2/model/component/mlstm_block.py
+++ b/src/tirex2/model/component/mlstm_block.py
@@ -1,6 +1,6 @@
+# Copyright (c) NXAI GmbH.
 """Wrapper around xlstm mLSTM blocks with TiRex-specific tweaks."""
 
-# From xlstm large
 from dataclasses import dataclass
 from typing import Literal
 

--- a/src/tirex2/model/component/mlstm_block.py
+++ b/src/tirex2/model/component/mlstm_block.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Wrapper around xlstm mLSTM blocks with TiRex-specific tweaks."""
 
 from dataclasses import dataclass

--- a/src/tirex2/model/component/patch_tokenizer.py
+++ b/src/tirex2/model/component/patch_tokenizer.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Patch-based tokenization utilities for TiRex models."""
 
 import torch

--- a/src/tirex2/model/component/patch_tokenizer.py
+++ b/src/tirex2/model/component/patch_tokenizer.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Patch-based tokenization utilities for TiRex models."""
 
 import torch

--- a/src/tirex2/model/component/postprocessor.py
+++ b/src/tirex2/model/component/postprocessor.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Single-pass, native-multivariate postprocessor with per-target differencing."""
 
 import logging

--- a/src/tirex2/model/component/postprocessor.py
+++ b/src/tirex2/model/component/postprocessor.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Single-pass, native-multivariate postprocessor with per-target differencing."""
 
 import logging

--- a/src/tirex2/model/component/residual_block.py
+++ b/src/tirex2/model/component/residual_block.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Residual MLP building blocks used across TiRex modules."""
 
 import torch

--- a/src/tirex2/model/component/residual_block.py
+++ b/src/tirex2/model/component/residual_block.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Residual MLP building blocks used across TiRex modules."""
 
 import torch

--- a/src/tirex2/model/component/scaler.py
+++ b/src/tirex2/model/component/scaler.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 """Random past-window standardization for stochastic normalization."""
 
 import torch

--- a/src/tirex2/model/component/scaler.py
+++ b/src/tirex2/model/component/scaler.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 """Random past-window standardization for stochastic normalization."""
 
 import torch

--- a/src/tirex2/model/component/variate_mixing_block.py
+++ b/src/tirex2/model/component/variate_mixing_block.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -172,7 +173,6 @@ class MultivariateBlock(nn.Module):
         # This treats L as the new batch dimension and mixes across B*V (all variates)
         x_variate = rearrange(time_output, "bv l p -> l bv p", bv=BV, l=L, p=P)  # [L, B*V, P]
 
-        # Apply variate mixing
         variate_output, _ = _unwrap_output(
             self.variate_mixer(x_variate, group_vector=group_vector, target_mask=target_mask)
         )
@@ -180,7 +180,7 @@ class MultivariateBlock(nn.Module):
         # Transpose back: [L, B*V, P] -> [B*V, L, P]
         x = rearrange(variate_output, "l bv p -> bv l p", l=L, bv=BV, p=P)
 
-        return x, {}  # TODO: return state as well for streaming
+        return x, {}
 
     def _build_time_mixer(self, config: TimeMixerConfig, block_idx: int, num_blocks: int) -> nn.Module:
         """Instantiate time mixing model from configuration.

--- a/src/tirex2/model/component/variate_mixing_block.py
+++ b/src/tirex2/model/component/variate_mixing_block.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from dataclasses import dataclass
 from typing import Any, Literal
 

--- a/src/tirex2/model/component/xlstm_mixed_config.py
+++ b/src/tirex2/model/component/xlstm_mixed_config.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from dataclasses import dataclass, field
 
 from xlstm.xlstm_large import xLSTMLargeConfig

--- a/src/tirex2/model/component/xlstm_mixed_config.py
+++ b/src/tirex2/model/component/xlstm_mixed_config.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from dataclasses import dataclass, field
 
 from xlstm.xlstm_large import xLSTMLargeConfig

--- a/src/tirex2/model/tirex2.py
+++ b/src/tirex2/model/tirex2.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 import importlib
 import logging
 from dataclasses import dataclass, replace
@@ -147,9 +149,6 @@ class TiRex2(nn.Module):
         if matmul_precision is not None:
             torch.set_float32_matmul_precision(matmul_precision)
 
-        # Older checkpoint configs may still carry a serialized postprocessor
-        # parameter block; differencing/calibration now uses code defaults and is
-        # toggled exclusively via ``tta_diff``.
         kwargs.pop("postprocessor_cfg", None)
         super().__init__(*args, **kwargs)
         act_func = _resolve_act_func(act_func)

--- a/src/tirex2/model/tirex2.py
+++ b/src/tirex2/model/tirex2.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 import importlib
 import logging
 from dataclasses import dataclass, replace

--- a/src/tirex2/model/types.py
+++ b/src/tirex2/model/types.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from dataclasses import dataclass
 
 import torch

--- a/src/tirex2/model/types.py
+++ b/src/tirex2/model/types.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from dataclasses import dataclass
 
 import torch

--- a/src/tirex2/plotting.py
+++ b/src/tirex2/plotting.py
@@ -1,4 +1,6 @@
 # Copyright (c) NXAI GmbH.
+# Licensed under the Apache License, Version 2.0; see LICENSE for details.
+
 from collections.abc import Sequence
 from itertools import chain
 

--- a/src/tirex2/plotting.py
+++ b/src/tirex2/plotting.py
@@ -1,3 +1,4 @@
+# Copyright (c) NXAI GmbH.
 from collections.abc import Sequence
 from itertools import chain
 
@@ -725,7 +726,6 @@ def plot_multivariate(
 
     if x is None:
         x = np.arange(full_size)
-        # x = np.arange(-input.past_length, max_future_length) + 1
     elif len(x) < full_size:
         raise ValueError(
             "Not enough 'x' values provided to have one for every timestep in context, forecast, and ground truth window."


### PR DESCRIPTION
This brings the Python files under `src/tirex2/` in line with `inference/` by applying the existing NXAI copyright and Apache license header consistently.

While going through the files, I also removed a few leftover debugging comments and cleaned up docstrings that no longer matched the implementation. This includes dropping the unused `return_attention_scores` option from `AttentionLayer`.

The inference test startup wait is increased from 30 to 60 seconds after model initialization exceeded the previous budget on GitHub-hosted runners.

No model computation was changed.

Tested with:

- `pytest -q test/` — 85 passed
- `ruff check src test inference/tests/conftest.py`
- `ruff format --check src test inference/tests/conftest.py`
- `python -m compileall -q inference/app inference/tests`
- `mkdocs build --strict`
- pre-commit hooks on all changed files

The only compatibility consideration is for code that explicitly passes `return_attention_scores` to `AttentionLayer`; that argument was unused and is no longer accepted.