### PR TITLE
docs(readme): add Windows compiler FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ We use [Pixi](https://pixi.prefix.dev/latest/) for our development and benchmark
 curl -fsSL https://pixi.sh/install.sh | sh
 ```
 
+## FAQ
+
+<details>
+<summary><strong>Why does TiRex-2 fail with <code>where cl</code> on Windows?</strong></summary>
+
+PyTorch may compile model components at runtime, so the Python process needs access to the MSVC C++ compiler, even when using `device="cpu"`.
+
+Install Visual Studio Build Tools with **Desktop development with C++**, then run TiRex-2 from an **x64 Native Tools Command Prompt for Visual Studio**. Confirm the compiler is available before starting your script:
+
+```bat
+where cl
+python your_script.py
+```
+
+Launch VS Code or Jupyter from the same prompt so it inherits the compiler environment. See [#17](https://github.com/NX-AI/tirex-2/issues/17) for details.
+
+</details>
+
 ## Getting started
 
 The most easy way for you to get started is by checking out our ["Getting Started" notebook](examples/getting_started.ipynb). Moreover, you can jump straight into testing out TiRex using [Google Colab](https://colab.research.google.com/github/NX-AI/tirex-2/blob/main/examples/getting_started.ipynb). If you have cloned this repository, you can also easily start the notebook via Pixi by running:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ where cl
 python your_script.py
 ```
 
-Launch VS Code or Jupyter from the same prompt so it inherits the compiler environment. See [#17](https://github.com/NX-AI/tirex-2/issues/17) for details.
+Launch VS Code or Jupyter from the same prompt so it inherits the compiler environment. See [#15](https://github.com/NX-AI/tirex-2/issues/15) and [#17](https://github.com/NX-AI/tirex-2/issues/17) for related reports.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,11 @@ curl -fsSL https://pixi.sh/install.sh | sh
 <details>
 <summary><strong>How do I run TiRex-2 on CUDA?</strong></summary>
 
-With `device="cuda"`, TiRex-2 builds its fused sLSTM kernel (FlashRNN) with `nvcc` on the first forecast. In order to run Tirex-2 on CUDA you need:
+With `device="cuda"`, TiRex-2 builds its fused sLSTM kernel (FlashRNN) with `nvcc` on the first forecast. In order to run TiRex-2 on CUDA you need:
 
 1. **A CUDA Toolkit installed and discoverable** — `nvcc` must be on `PATH` or reachable via `CUDA_HOME`.
-2. **A CUDA toolkit whose major version matches your PyTorch build** — any 12.x toolkit for a `cu12x` torch wheel, any 13.x toolkit for a `cu13x` one. Check with `python -c "import torch; print(torch.version.cuda)"`.
-
-3. **A CUDA toolkit no newer than your driver supports.**
+2. **A CUDA Toolkit whose major version matches your PyTorch build** — any 12.x toolkit for a `cu12x` torch wheel, any 13.x toolkit for a `cu13x` one. Check with `python -c "import torch; print(torch.version.cuda)"`.
+3. **A CUDA Toolkit no newer than your driver supports.**
 
 </details>
 
@@ -84,7 +83,6 @@ With `device="cuda"`, TiRex-2 builds its fused sLSTM kernel (FlashRNN) with `nvc
 <summary><strong>Which NVIDIA GPU architectures does TiRex-2 support?</strong></summary>
 
 - TiRex-2 runs on NVIDIA GPUs with compute capability 8.0 (Ampere) or newer.
-
 - Older cards — Turing (7.5), Volta (7.0) and earlier — cannot run `device="cuda"`; use `device="cpu"` instead.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ curl -fsSL https://pixi.sh/install.sh | sh
 ## FAQ
 
 <details>
+<summary><strong>How do I run TiRex-2 on CUDA?</strong></summary>
+
+With `device="cuda"`, TiRex-2 builds its fused sLSTM kernel (FlashRNN) with `nvcc` on the first forecast. In order to run Tirex-2 on CUDA you need:
+
+1. **A CUDA Toolkit installed and discoverable** — `nvcc` must be on `PATH` or reachable via `CUDA_HOME`.
+2. **A CUDA toolkit whose major version matches your PyTorch build** — any 12.x toolkit for a `cu12x` torch wheel, any 13.x toolkit for a `cu13x` one. Check with `python -c "import torch; print(torch.version.cuda)"`.
+
+3. **A CUDA toolkit no newer than your driver supports.**
+
+</details>
+
+<details>
+<summary><strong>Which NVIDIA GPU architectures does TiRex-2 support?</strong></summary>
+
+- TiRex-2 runs on NVIDIA GPUs with compute capability 8.0 (Ampere) or newer.
+
+- Older cards — Turing (7.5), Volta (7.0) and earlier — cannot run `device="cuda"`; use `device="cpu"` instead.
+
+</details>
+
+<details>
 <summary><strong>Why does TiRex-2 fail with <code>where cl</code> on Windows?</strong></summary>
 
 PyTorch may compile model components at runtime, so the Python process needs access to the MSVC C++ compiler, even when using `device="cpu"`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,3 +33,5 @@
     ```
 
     Launch VS Code or Jupyter from the same prompt so it inherits the compiler environment.
+    See [#15](https://github.com/NX-AI/tirex-2/issues/15) and
+    [#17](https://github.com/NX-AI/tirex-2/issues/17) for related reports.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,35 @@
+# FAQ
+
+??? question "How do I run TiRex-2 on CUDA?"
+
+    With `device="cuda"`, TiRex-2 builds its fused sLSTM kernel (FlashRNN) with `nvcc` on the
+    first forecast. In order to run TiRex-2 on CUDA you need:
+
+    1. **A CUDA Toolkit installed and discoverable** — `nvcc` must be on `PATH` or reachable
+       via `CUDA_HOME`.
+    2. **A CUDA Toolkit whose major version matches your PyTorch build** — any 12.x toolkit
+       for a `cu12x` torch wheel, any 13.x toolkit for a `cu13x` one. Check with
+       `python -c "import torch; print(torch.version.cuda)"`.
+    3. **A CUDA Toolkit no newer than your driver supports.**
+
+??? question "Which NVIDIA GPU architectures does TiRex-2 support?"
+
+    - TiRex-2 runs on NVIDIA GPUs with compute capability 8.0 (Ampere) or newer.
+    - Older cards — Turing (7.5), Volta (7.0) and earlier — cannot run `device="cuda"`; use
+      `device="cpu"` instead.
+
+??? question "Why does TiRex-2 fail with `where cl` on Windows?"
+
+    PyTorch may compile model components at runtime, so the Python process needs access to
+    the MSVC C++ compiler, even when using `device="cpu"`.
+
+    Install Visual Studio Build Tools with **Desktop development with C++**, then run
+    TiRex-2 from an **x64 Native Tools Command Prompt for Visual Studio**. Confirm the
+    compiler is available before starting your script:
+
+    ```bat
+    where cl
+    python your_script.py
+    ```
+
+    Launch VS Code or Jupyter from the same prompt so it inherits the compiler environment.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -30,4 +30,5 @@ Environments (e.g. `example-cu128`) are defined in
 
 ## Next steps
 
-Continue with the [Quickstart](quickstart.md) for a first forecast.
+Continue with the [Quickstart](quickstart.md) for a first forecast. If you plan to run on a
+GPU, see the [FAQ](../faq.md) for the CUDA Toolkit and GPU architecture requirements.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs>=1.6
+mkdocs>=1.6,<2
 mkdocs-material>=9.5
 mkdocstrings[python]>=0.26
 mkdocs-material-extensions>=1.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Forecasting: how-to/forecasting.md
       - Covariates: how-to/covariates.md
       - Streaming: how-to/streaming.md
+  - FAQ: faq.md
   - Benchmarks: benchmarks.md
   - Deployment: deployment.md
   - TiRex-2 Pro: pro.md


### PR DESCRIPTION
## Summary

Add a short, collapsible FAQ entry for the common Windows `where cl` failure.

## Motivation

PyTorch runtime compilation can require the MSVC C++ toolchain on Windows, including CPU inference paths. The current error does not explain that the launching process must inherit the Visual Studio developer environment.

## Main changes

- explain the missing `cl.exe` cause
- point users to Visual Studio Build Tools and the x64 Native Tools prompt
- note that VS Code and Jupyter must be launched from the same prompt
- link to related issues #15 and #17

## Testing

- `uvx pre-commit run --files README.md`
- `git diff --check`
- rendered the README through GitHub's GFM Markdown API and verified the folded `<details>` block and both issue links

## Risks / follow-ups

Documentation-only change; no runtime behavior is affected. This documents the current Windows workaround rather than expanding the repository's stated platform support.

Addresses #15 and #17.