### PR TITLE
Dev: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,8 +45,7 @@ body:
         - 3.11 (Minimum supported)
         - 3.12
         - 3.13
-        - 3.14 (Latest stable)
-        - 3.15 (Preview)
+        - 3.14 (Latest tested)
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - daidahao
+body:
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Describe the bug in one sentence.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Please provide steps and code snippets to help us reproduce the bug.
+      value: |
+        1. ...
+        2. ...
+
+        Code snippet:
+
+        ```python
+        # Your code here
+        ```
+  - type: textarea
+    id: log_output
+    attributes:
+      label: Log Output
+      placeholder: Paste any relevant log output here.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: python
+    attributes:
+      label: Python Version
+      options:
+        - 3.11 (Minimum supported)
+        - 3.12
+        - 3.13
+        - 3.14 (Latest stable)
+        - 3.15 (Preview)
+      default: 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: system_info
+    attributes:
+      label: System Information
+      placeholder: Please provide relevant system information (e.g., OS, hardware specs).
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filling out this bug report! We will look into the issue as soon as possible.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["feature", "triage"]
+assignees:
+  - daidahao
+body:
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency
+      description: How urgent is this feature request?
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Describe the feature you want in one or two sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation
+      placeholder: If you have ideas about how to implement this feature, please share them here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      placeholder: If this feature is not implemented, what are the alternatives?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      placeholder: Add any other context or code snippets about the feature request here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: checklist
+    attributes:
+      label: Checklist
+      value: |
+        - [ ] I have searched the existing issues to ensure this has not been reported yet.
+        - [ ] I have checked the documentation to ensure this feature does not already exist.
+        - [ ] I have provided a clear and concise description of the feature.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a new feature! We will review your request and get back to you soon.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 - [ ] Provided a summary of this PR under **Summary**.
 - [ ] Added or updated unit tests ([/test](/test)) affected by this PR and passed all tests.
 - [ ] Maintained or improved code coverage as per "Codedev" report.
-<!-- - [ ] Updated [/CHANGRLOG.md](/CHANGELOG.md) to reflect major changes. -->
+<!-- - [ ] Updated [/CHANGELOG.md](/CHANGELOG.md) to reflect major changes. -->
 
 ## Issues
 <!-- Please mention any issues this PR will fix or close. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Checklist
 <!-- You should replace `[ ]` with `[x]` on each item you have completed. -->
-- [ ] Mentioned issue(s) related to this PRunder **Issues**.
+- [ ] Mentioned issue(s) related to this PR under **Issues**.
 - [ ] Provided a summary of this PR under **Summary**.
 - [ ] Added or updated unit tests ([/test](/test)) affected by this PR and passed all tests.
 - [ ] Maintained or improved code coverage as per "Codedev" report.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Checklist
+<!-- You should replace `[ ]` with `[x]` on each item you have completed. -->
+- [ ] Mentioned issue(s) related to this PRunder **Issues**.
+- [ ] Provided a summary of this PR under **Summary**.
+- [ ] Added or updated unit tests ([/test](/test)) affected by this PR and passed all tests.
+- [ ] Maintained or improved code coverage as per "Codedev" report.
+<!-- - [ ] Updated [/CHANGRLOG.md](/CHANGELOG.md) to reflect major changes. -->
+
+## Issues
+<!-- Please mention any issues this PR will fix or close. -->
+Fixes #
+
+## Summary
+<!-- Please provide a brief summary of this PR. -->
+
+## Notes
+<!-- Leave any additional information here related to this PR. -->
+
+<!-- Thank you for your contributions to the library! -->


### PR DESCRIPTION
## Checklist
- [x] Provided a summary of this PR under **Summary**.
- [ ] Added or updated unit tests affected by this PR and passed all tests. (Not applicable: templates only.)
- [ ] Maintained or improved code coverage. (Not applicable: no executable code changes.)

## Issues
No related issue specified.

## Summary
Add GitHub issue forms for bug reports and feature requests, plus a pull request template to guide contribution summaries and review checklists.

Bug reports collect reproduction steps, logs, Python version, and system information. Feature requests collect urgency, implementation ideas, alternatives, and a submission checklist. Both forms assign incoming issues to daidahao and apply triage labels.

## Notes
Validation: `git diff --cached --check` passed before committing. Application tests were not run because this change adds only GitHub contribution templates.
