### PR TITLE
Chore: remove redundant no_grad context

### DIFF
--- a/src/tirex2/model/tirex2.py
+++ b/src/tirex2/model/tirex2.py
@@ -455,14 +455,13 @@ class TiRex2(nn.Module):
         elif context.shape[-1] > max_ts_len:
             context = context[..., -max_ts_len:]
 
-        with torch.no_grad():
-            batch = {"x": context, "group_vector": group_vector, "target_mask": target_mask}
-            pred = self(batch)
-            # Drop the last token (predicts beyond sequence end); the remaining
-            # tail of length future_len covers exactly the 10 future patches
-            # that were directly supervised during training.
-            pred = pred[..., : -self.output_patch_size]
-            pred = pred[:, :, -self.future_len :]
+        batch = {"x": context, "group_vector": group_vector, "target_mask": target_mask}
+        pred = self(batch)
+        # Drop the last token (predicts beyond sequence end); the remaining
+        # tail of length future_len covers exactly the 10 future patches
+        # that were directly supervised during training.
+        pred = pred[..., : -self.output_patch_size]
+        pred = pred[:, :, -self.future_len :]
 
         return pred[:, :, :prediction_length]
 


### PR DESCRIPTION
## Checklist
- [x] Mentioned issue(s) related to this PR under **Issues**.
- [x] Provided a summary of this PR under **Summary**.
- [ ] Added or updated unit tests affected by this PR and passed all tests.
- [ ] Maintained or improved code coverage as per "Codedev" report.

## Issues
None.

## Summary
Remove the redundant `torch.no_grad()` context in `TiRex2._predict()`. The public `predict()` method already disables gradients through its decorator, so public prediction behavior is unchanged.

Direct calls to the private `_predict()` method now respect the caller's gradient mode.

## Notes
Validation: `git diff --check` passed. Tests were not run for this context removal and indentation change.
