### PR TITLE
CI: use Pixi for platform matrix and lower-bound tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,8 @@ jobs:
           # PyTorch 2.8 imports setuptools from torch.utils.cpp_extension.
           pixi add --feature test "python=3.11.*" "setuptools>=68" --no-install
           pixi add --feature test --platform linux-64-cpu --pypi "torch==2.8.0" --index https://download.pytorch.org/whl/cpu --no-install
+          # Match PyTorch 2.8's Triton version; flashrnn otherwise pulls an unconstrained version.
+          pixi add --feature test --platform linux-64-cpu --pypi "triton==3.4.0" --no-install
 
       - name: Run tests on CPU
         run: pixi run test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Select lowest supported Python and CPU torch versions
         run: |
-          pixi add --feature test "python=3.11.*" --no-install
+          # PyTorch 2.8 imports setuptools from torch.utils.cpp_extension.
+          pixi add --feature test "python=3.11.*" "setuptools>=68" --no-install
           pixi add --feature test --platform linux-64-cpu --pypi "torch==2.8.0" --index https://download.pytorch.org/whl/cpu --no-install
 
       - name: Run tests on CPU

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Select preview Python version for the test environment
         run: |
-          pixi workspace channel add --feature test conda-forge/label/python_rc --no-install
+          pixi workspace channel add --feature test conda-forge/label/python_rc --priority -1 --no-install
           pixi add --feature test --platform linux-64-cpu "python=3.15.*" --no-install
 
       - name: Run tests on CPU

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,24 +47,20 @@ jobs:
       - name: Run tests on CPU
         run: pixi run test
 
-  # Keep one non-editable pip install to cover packaging and the supported minima.
   core-tests-lowest-bound:
     name: core-tests lowest bound (py3.11, torch2.8.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
         with:
-          python-version: "3.11"
+          run-install: false
+          cache: false
 
-      - name: Install CPU torch at the lowest bound
-        run: python -m pip install "torch==2.8.0" --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Install tirex-2 from source with torch constrained
-        run: python -m pip install ".[gluonts,fev]" "torch==2.8.0" pytest pandas
-
-      - name: Check dependency compatibility
-        run: python -m pip check
+      - name: Select lowest supported Python and CPU torch versions
+        run: |
+          pixi add --feature test "python=3.11.*" --no-install
+          pixi add --feature test --platform linux-64-cpu --pypi "torch==2.8.0" --index https://download.pytorch.org/whl/cpu --no-install
 
       - name: Run tests on CPU
-        run: python -m pytest test/
+        run: pixi run test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Select preview Python version for the test environment
         run: |
-          pixi workspace channel add --feature test conda-forge/label/python_rc --priority -1 --no-install
+          pixi workspace channel add --feature test conda-forge/label/python_rc --priority=-1 --no-install
           pixi add --feature test --platform linux-64-cpu "python=3.15.*" --no-install
 
       - name: Run tests on CPU

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   core-tests:
     name: core-tests (py${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,29 +8,19 @@ on:
 
 jobs:
   core-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
-        with:
-          frozen: true
-
-      - name: Run tests on CPU
-        run: pixi run test
-
-  core-tests-pip:
     name: core-tests (py${{ matrix.python-version }}, ${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
         with:
-          python-version: ${{ matrix.python-version }}
+          run-install: false
+          cache: false
 
       - name: Set up MSVC (for torch.compile on windows)
         if: runner.os == 'Windows'
@@ -50,11 +40,31 @@ jobs:
             "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           }
 
-      - name: Install CPU torch
-        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Install tirex-2 from source
-        run: pip install ".[gluonts,fev]" pytest pandas
+      # Resolve each Python version instead of reusing the lockfile's Python.
+      - name: Select Python version for the test environment
+        run: pixi add --feature test "python=${{ matrix.python-version }}.*" --no-install
 
       - name: Run tests on CPU
-        run: pytest test/
+        run: pixi run test
+
+  # Keep one non-editable pip install to cover packaging and the supported minima.
+  core-tests-lowest-bound:
+    name: core-tests lowest bound (py3.11, torch2.8.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install CPU torch at the lowest bound
+        run: python -m pip install "torch==2.8.0" --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install tirex-2 from source with torch constrained
+        run: python -m pip install ".[gluonts,fev]" "torch==2.8.0" pytest pandas
+
+      - name: Check dependency compatibility
+        run: python -m pip check
+
+      - name: Run tests on CPU
+        run: python -m pytest test/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   core-tests:
     name: core-tests (py${{ matrix.python-version }}, ${{ matrix.os }})
@@ -74,8 +78,6 @@ jobs:
   core-tests-preview:
     name: core-tests preview (py3.15, ubuntu-latest)
     runs-on: ubuntu-latest
-    # Preview dependency availability and compatibility should not block stable CI.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
@@ -84,6 +86,8 @@ jobs:
           cache: false
 
       - name: Select preview Python version for the test environment
+        # Preview dependency availability and compatibility should not block stable CI.
+        continue-on-error: true
         run: |
           pixi workspace channel add --feature test conda-forge/label/python_rc --priority=-1 --no-install
           pixi add --feature test --platform linux-64-cpu "python=3.15.*" --no-install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,3 +70,23 @@ jobs:
 
       - name: Run tests on CPU
         run: pixi run test
+
+  core-tests-preview:
+    name: core-tests preview (py3.15, ubuntu-latest)
+    runs-on: ubuntu-latest
+    # Preview dependency availability and compatibility should not block stable CI.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
+        with:
+          run-install: false
+          cache: false
+
+      - name: Select preview Python version for the test environment
+        run: |
+          pixi workspace channel add --feature test conda-forge/label/python_rc --no-install
+          pixi add --feature test --platform linux-64-cpu "python=3.15.*" --no-install
+
+      - name: Run tests on CPU
+        run: pixi run test


### PR DESCRIPTION
## Checklist

- [x] Mentioned related issues under **Issues**.
- [x] Provided a summary under **Summary**.
- [ ] Added or updated affected unit tests and passed all tests (workflow-only change; Python 3.15 validation remains unavailable).
- [ ] Maintained or improved code coverage as per "Codedev" report.

## Issues

No linked issue.

## Summary

Replace the pip CPU test matrix with Pixi jobs covering Python 3.11 and 3.14 on Ubuntu, Windows, and macOS. Resolve the test environment for each Python version, disable environment caching, and preserve MSVC setup on Windows for `torch.compile`.

Add two Ubuntu jobs:

- Lowest bound: Python 3.11 with CPU PyTorch 2.8.0, explicit setuptools for extension imports, and Triton 3.4.0 to match PyTorch's compiler API.
- Preview: attempt Python 3.15 using conda-forge plus the lower-priority `python_rc` channel. Only the version-selection step allows failure; the subsequent test step runs normally.

Limit workflow permissions to `contents: read` and cancel superseded runs of the same workflow for each PR or branch.

## Notes

All six stable matrix jobs, the lowest-bound job, inference tests, pre-commit checks, and CodeQL pass on the latest run. Local workflow YAML checks and `git diff --check` also passed.

The preview job is green but does **not** yet validate Python 3.15: dependency resolution fails because the available PyYAML versions have no usable Python 3.15 wheels under the project's `no-build` policy. With setup failure allowed, the subsequent tests ran on Python 3.14.7 (70 passed, 15 skipped). Python 3.15 compatibility remains unverified.
