### PR TITLE
CI: test dependencies from frozen pixi lockfile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,19 @@ jobs:
       - name: Run tests on CPU
         run: pixi run test
 
+  core-tests-frozen:
+    name: core-tests frozen (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
+        with:
+          run-install: false
+          cache: false
+
+      - name: Run tests on CPU using pixi.lock
+        run: pixi run --frozen test
+
   core-tests-lowest-bound:
     name: core-tests lowest bound (py3.11, torch2.8.0)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Checklist
- [x] Mentioned issue(s) related to this PR under **Issues**.
- [x] Provided a summary of this PR under **Summary**.
- [ ] Added or updated unit tests affected by this PR and passed all tests.
- [ ] Maintained or improved code coverage as per "Codedev" report.

## Issues
No linked issue.

## Summary
Add an Ubuntu `core-tests-frozen` job that runs `pixi run --frozen test` using the committed `pixi.lock`. This exercises the locked dependency versions alongside the existing jobs that resolve dependencies.

## Notes
Validation: `git diff --check` passed. CI tests were not run locally.
